### PR TITLE
Update debian-control

### DIFF
--- a/debian-control
+++ b/debian-control
@@ -3,7 +3,7 @@ Version: 2.0.0-evolution-3.38
 Architecture: amd64
 Maintainer: Aldo Gunsing <dev@aldogunsing.nl>
 Homepage: https://github.com/39aldo39/Evolution-DecSync
-Depends: evolution (>= 3.38), libdecsync (>= 2.0.1), libjson-c4
+Depends: evolution (>= 3.38), libdecsync (>= 2.0.1), libjson-c4 | libjson-c5
 Description: DecSync synchronization for Evolution
  DecSync for Evolution is an Evolution plugin which synchronizes contacts and calendars using DecSync.
  To start synchronizing, all you have to do is synchronize the DecSync directory (by default ~/.local/share/decsync), using for example Syncthing.


### PR DESCRIPTION
Fix Evolution 3.38 package for Debian 11 (works at least for me) by adding alternative dependency; issue #38